### PR TITLE
Update deprecated ITKV3 names

### DIFF
--- a/SegmentationAidedRegistration/lib/reg_3d_affine_mse.hxx
+++ b/SegmentationAidedRegistration/lib/reg_3d_affine_mse.hxx
@@ -132,7 +132,7 @@ namespace gth818n
 
     try
       {
-        registration->StartRegistration();
+      registration->Update();
         //     std::cout << "Optimizer stop condition: "
         //               << registration->GetOptimizer()->GetStopConditionDescription()
         //               << std::endl;

--- a/SegmentationAidedRegistration/lib/transformImage.hxx
+++ b/SegmentationAidedRegistration/lib/transformImage.hxx
@@ -113,7 +113,7 @@ namespace gth818n
     warper->SetOutputSpacing( referenceImage->GetSpacing() );
     warper->SetOutputOrigin( referenceImage->GetOrigin() );
     warper->SetEdgePaddingValue( fillInValue );
-    warper->SetDeformationField( vectorField );
+    warper->SetDisplacementField( vectorField );
     warper->Update();
 
     //tst

--- a/SegmentationAidedRegistration/lib/utilities.h
+++ b/SegmentationAidedRegistration/lib/utilities.h
@@ -12,9 +12,6 @@
 #include "itkImageRegionIterator.h"
 #include "itkBinaryThresholdImageFilter.h"
 
-#include "itkMultiplyByConstantImageFilter.h"
-
-
 #include <csignal>
 
 namespace gth818n

--- a/SegmentationAidedRegistration/lib/utilities.hxx
+++ b/SegmentationAidedRegistration/lib/utilities.hxx
@@ -14,7 +14,7 @@
 #include "itkImageRegionConstIterator.h"
 #include "itkImageRegionIterator.h"
 
-#include "itkMultiplyByConstantImageFilter.h"
+#include "itkMultiplyImageFilter.h"
 
 #include "itkRegionOfInterestImageFilter.h"
 
@@ -240,10 +240,10 @@ namespace gth818n
   typename itk::Image<unsigned char, 3>::Pointer
   postProcessProbabilityMap(typename image_t::Pointer probMap, typename image_t::PixelType c)
   {
-    typedef itk::MultiplyByConstantImageFilter< image_t, typename image_t::PixelType, itk::Image<unsigned char, 3> > \
-      itkMultiplyByConstantImageFilter_t;
+    typedef itk::MultiplyImageFilter< image_t, typename image_t::PixelType, itk::Image<unsigned char, 3> > \
+      itkMultiplyImageFilter_t;
 
-    typename itkMultiplyByConstantImageFilter_t::Pointer mul = itkMultiplyByConstantImageFilter_t::New();
+    typename itkMultiplyImageFilter_t::Pointer mul = itkMultiplyImageFilter_t::New();
     mul->SetInput(probMap);
     mul->SetConstant(c);
     mul->Update();


### PR DESCRIPTION
ITKV3_COMPATIBILITY will be disabled. Update the name of methods and
classes to their modern equivalent.